### PR TITLE
Drop ocaml prefix for semaphore name to comply with OSX 31 char limit

### DIFF
--- a/parany.ml
+++ b/parany.ml
@@ -22,7 +22,7 @@ module Sem = struct
 
   let create value =
     let name =
-      sprintf "/ocaml_libparany_pid_%d_sem_%d" !count (Unix.getpid ()) in
+      sprintf "/libparany_pid_%d_sem_%d" !count (Unix.getpid ()) in
     incr count;
     (* printf "sem_name: %s\n%!" name; *)
     let sem = sem_open name [SEM_O_CREAT] 0o600 value in


### PR DESCRIPTION
To fix #12 