### PR TITLE
Marshalling of closures

### DIFF
--- a/src/parany.ml
+++ b/src/parany.ml
@@ -19,7 +19,7 @@ module Shm = struct
 
   let marshal_to_file fn v =
     let out = open_out_bin fn in
-    Marshal.to_channel out v [Marshal.No_sharing];
+    Marshal.to_channel out v Marshal.[No_sharing; Closures];
     close_out out
 
   let rec send_loop sock buff n =


### PR DESCRIPTION
Thanks for this super helpful library.

It would be useful for me if demux could return closures. I changed `marshal_to_file` locally and it seems to work for my use case. Is it generally safe to do that? If yes, I propose merging this change. If not, what do you think about adding an option to enable the unsafe but useful behavior?