### PR TITLE
parany: use Filename.get_temp_dir

### DIFF
--- a/src/parany.ml
+++ b/src/parany.ml
@@ -66,7 +66,8 @@ let feed_them_all csize ncores demux queue =
   (* let pid = Unix.getpid () in
    * eprintf "feeder(%d) started\n%!" pid; *)
   let in_count = ref 0 in
-  let prfx = Filename.temp_file ~temp_dir:"/tmp" "iparany_" "" in
+  let temp_dir = Filename.get_temp_dir_name () in
+  let prfx = Filename.temp_file ~temp_dir "iparany_" "" in
   let to_send = ref [] in
   try
     while true do
@@ -188,7 +189,8 @@ let run ?(init = fun (_rank: int) -> ()) ?(finalize = fun () -> ())
           (* parmap also does core pinning _after_ having called
              the per-process init function *)
           if core_pin then Cpu.setcore worker_rank;
-          let prfx = Filename.temp_file ~temp_dir:"/tmp" "oparany_" "" in
+          let temp_dir = Filename.get_temp_dir_name () in
+          let prfx = Filename.temp_file ~temp_dir "oparany_" "" in
           at_exit (fun () ->
               (* tell collector to stop *)
               (* eprintf "worker(%d) finished\n%!" pid; *)


### PR DESCRIPTION
Tested on macos with and without sandbox and worked fine.

Signed-off-by: Marcello Seri <marcello.seri@gmail.com>